### PR TITLE
Update reporting for ELKR and one modelled crossing fix

### DIFF
--- a/01_prep/barriers/05_modelled_stream_crossings/data/modelled_stream_crossings_fixes.csv
+++ b/01_prep/barriers/05_modelled_stream_crossings/data/modelled_stream_crossings_fixes.csv
@@ -1900,3 +1900,4 @@ modelled_crossing_id,structure,watershed_group_code,reviewer,notes
 4606377,OBS,ELKR,NMW,bridge/OBS
 4603555,NONE,ELKR,NMW,no road/structure
 24734790,NONE,ELKR,NMW,Local knowledge; cut block site visited by partner and no road/structure exists
+4602684,NONE,ELKR,NMW,no road/structure

--- a/04_reporting/wcrp/sql/barrier_extent.sql
+++ b/04_reporting/wcrp/sql/barrier_extent.sql
@@ -14,8 +14,9 @@ SELECT
   ROUND(SUM(all_rearing_belowupstrbarriers_km)::numeric, 2) as all_rearing_blocked_km,
   ROUND(SUM(all_spawningrearing_belowupstrbarriers_km)::numeric, 2) as all_spawningrearing_blocked_km
 FROM bcfishpass.crossings
-WHERE watershed_group_code in ('BULK','LNIC','HORS')
+WHERE watershed_group_code in ('BULK','LNIC','HORS','ELKR')
 AND barrier_status IN ('POTENTIAL', 'BARRIER')
+AND aggregated_crossings_id != 1100001508 -- don't count the Elko Dam in ELKR
 GROUP BY
   watershed_group_code,
   wcrp_barrier_type

--- a/04_reporting/wcrp/sql/dci_elkr_above_elko.sql
+++ b/04_reporting/wcrp/sql/dci_elkr_above_elko.sql
@@ -1,14 +1,26 @@
--- calculate DCI for Elk River system above Elko dam
+-- calculate DCIa and DCIp for Elk River system above Elko dam
 
--- First, find the lengths of each portion of stream between barriers/potential barriers
-WITH segments AS
+-- First, get total stream lengths for DCI_a (aka Longest Fragment) for habitat ONLY
+
+WITH lengths_a AS
+(SELECT
+  SUM(ST_Length(geom)) FILTER (WHERE dnstr_barriers_anthropogenic = ARRAY[1100001508]) as length_accessible,
+  SUM(ST_Length(geom)) FILTER (WHERE dnstr_barriers_anthropogenic <> ARRAY[1100001508]) as length_inaccessible
+FROM bcfishpass.streams
+WHERE (rearing_model_wct IS TRUE OR spawning_model_wct IS TRUE)
+AND FWA_Upstream(356570562, 22910, 22910, '300.625474.584724'::ltree, '300.625474.584724.100997'::ltree, blue_line_key, downstream_route_measure, wscode_ltree, localcode_ltree) -- only above Elko Dam
+
+),
+
+-- Second, find the lengths of each portion of stream between barriers/potential barriers for habitat ONLY
+segments AS
 (
   SELECT
     watershed_group_code,
     dnstr_barriers_anthropogenic,
     SUM(ST_Length(geom)) as length_segment
   FROM bcfishpass.streams
-  WHERE accessibility_model_wct IS NOT NULL
+  WHERE (rearing_model_wct IS TRUE OR spawning_model_wct IS TRUE)
   AND FWA_Upstream(356570562, 22910, 22910, '300.625474.584724'::ltree, '300.625474.584724.100997'::ltree, blue_line_key, downstream_route_measure, wscode_ltree, localcode_ltree) -- only above Elko Dam
   GROUP BY watershed_group_code, dnstr_barriers_anthropogenic
 ),
@@ -21,13 +33,31 @@ totals AS
    sum(length_segment) as length_total
   FROM segments
   GROUP BY watershed_group_code
-)
+),
 
--- calculate DCI
+-- calculate DCI_p
+dci_p AS
+(
 SELECT
   t.watershed_group_code,
   ROUND(SUM((s.length_segment * s.length_segment) / (t.length_total * t.length_total))::numeric, 4) as dci_p
 FROM segments s
 INNER JOIN totals t
 ON s.watershed_Group_code = t.watershed_group_code
-GROUP BY t.watershed_group_code;
+GROUP BY t.watershed_group_code
+),
+
+-- calculate DCI_a
+dci_a AS
+(
+SELECT
+ round((length_accessible / (length_accessible + length_inaccessible))::numeric, 4) as dci_a
+FROM lengths_a)
+
+-- report
+SELECT
+  length_accessible,
+  (length_accessible + length_inaccessible) as length_all_habitat,
+  a.dci_a,
+  p.dci_p
+FROM lengths_a,dci_a a, dci_p p


### PR DESCRIPTION
Fixes include:
- Calculating DCIa and DCIp for both above and below dam, and switching to based on habitat rather than potentially accessible streams
- Add ELKR to barrier_extent reporting
- Modelled crossing fix for modelled_crossing_id = 4602684