### PR TITLE
NewGraph crossing updates 2025-01-21

### DIFF
--- a/data/pscis_modelledcrossings_streams_xref.csv
+++ b/data/pscis_modelledcrossings_streams_xref.csv
@@ -3564,3 +3564,4 @@ stream_crossing_id,modelled_crossing_id,linear_feature_id,watershed_group_code,r
 198882,11303627,,LNIC,LB,Matched to closest modelled crossing.
 197571,4600316,,ELKR,MC,satellite imagery shows stream flowing to north before crossing under road. Matched PSCIS 197571
 198944,24601268,,ZYMO,LS,Matched to modelled crossing 24601268 as per 2023 field assessment. Currenly incorrectly linked to modelled crossing 24742819.
+58264,1800143,,BULK,LS,"Simpson Creek is incorrectly mapped in FWA, and PSCIS crossing 58264 should be linked to modelled crossing 1800143, confirmed during 2024 field assessment. Modelled crossing 1800143 is currenly incorrectly linked to PSCIS crossing 58258."

--- a/data/pscis_modelledcrossings_streams_xref.csv
+++ b/data/pscis_modelledcrossings_streams_xref.csv
@@ -3563,3 +3563,4 @@ stream_crossing_id,modelled_crossing_id,linear_feature_id,watershed_group_code,r
 198881,11300797,,LNIC,LB,Matched to closest modelled crossing.
 198882,11303627,,LNIC,LB,Matched to closest modelled crossing.
 197571,4600316,,ELKR,MC,satellite imagery shows stream flowing to north before crossing under road. Matched PSCIS 197571
+198944,24601268,,ZYMO,LS,Matched to modelled crossing 24601268 as per 2023 field assessment. Currenly incorrectly linked to modelled crossing 24742819.

--- a/data/user_cabd_dams_exclusions.csv
+++ b/data/user_cabd_dams_exclusions.csv
@@ -1,1 +1,2 @@
 cabd_id,reviewer_name,review_date,source,notes
+ae10a5fe-483d-463e-b973-08453dd66701,LS,2025-01-21,"imagery, FISS obs","No dam here, can't see anything on satellite imagery and known CH stream with major restoration work done upstream."

--- a/data/user_modelled_crossing_fixes.csv
+++ b/data/user_modelled_crossing_fixes.csv
@@ -21090,3 +21090,4 @@ modelled_crossing_id,structure,watershed_group_code,reviewer_name,review_date,so
 1004605216,NONE,ELKR,MC,2024-11-08,Elk WCRP excluded structures list,
 1024735443,NONE,ELKR,MC,2024-11-08,Elk WCRP excluded structures list,Recreational trail erroneously mapped in Digital Road Atlas
 1004606284,FORD,ELKR,MC,2024-11-08,Elk WCRP excluded structures list,Confirmed via literature: Cope et al. (2016)
+24704176,NONE,PARS,LS,2025-01-21,Local Knowledge,Duplicate of crossing 16602775. 24704176 should be removed. Confirmed during field assessment. 


### PR DESCRIPTION
- removed duplicate crossing `24704176` from Parsnip watershed group
- removed a dam on Ormand Creek in the Francois Lake watershed group
- Linking PSCIS crossing `198944` to modelled crossing `24601268` on Triburary to Zymoetz River in the ZYMO watershed group.
- force the linkage of PSCIS crossing `58264` to modelled crossing `1800143` on Gershwin Creek in the BULK watershed group