### PR TITLE
Include rehabilitated, exclude fords

### DIFF
--- a/jobs/auto_rank.py
+++ b/jobs/auto_rank.py
@@ -228,7 +228,8 @@ def runQuery(condition, wcrp, wcrp_schema, conn):
             where cv.barrier_status != 'PASSABLE'
             AND cv.all_spawningrearing_belowupstrbarriers_km  IS NOT NULL
             AND cv.all_spawningrearing_km  != 0
-            AND (tt.structure_list_status not in ('Rehabilitated barrier', 'Excluded structure')
+            AND NOT (cv.crossing_subtype_code = 'FORD' AND cv.barrier_status != 'BARRIER')
+            AND (tt.structure_list_status not in ('Excluded structure')
 		        OR tt.structure_list_status is null)
             AND {condition};
 


### PR DESCRIPTION
- Re-include rehabilitated barriers in rankings.
- Exclude fords not marked as barriers from rankings.