### PR TITLE
lnic-habitat-updates-oct2025

### DIFF
--- a/data/user_habitat_classification.csv
+++ b/data/user_habitat_classification.csv
@@ -6196,9 +6196,9 @@
 356362330,3815,3915,MIDR,CH,spawning,t,SN,2023-08-17,FISS spawning points,
 356362330,3815,3915,MIDR,SK,spawning,t,SN,2023-08-17,FISS spawning points,
 356362363,46.81,5213.5,HARR,ST,spawning,t,SN,2023-08-11,Pacific Salmon Foundation,
-356362373,0,"8,944",LNIC,CO,spawning,t,LB,2025-10-06,cwf,spawning habitat does not go beyond falls with ID 155d09fe-9e10-4baf-b6fb-718d1b975506
+356362373,0,8944,LNIC,CO,spawning,t,LB,2025-10-06,cwf,spawning habitat does not go beyond falls with ID 155d09fe-9e10-4baf-b6fb-718d1b975506
 356362373,0,100,LNIC,ST,spawning,t,LB,2025-10-06,cwf,spawning habitat does not go beyond falls with ID 155d09fe-9e10-4baf-b6fb-718d1b975506
-356362373,0,"8,944",LNIC,CH,spawning,t,LB,2025-10-06,cwf,spawning habitat does not go beyond falls with ID 155d09fe-9e10-4baf-b6fb-718d1b975506
+356362373,0,8944,LNIC,CH,spawning,t,LB,2025-10-06,cwf,spawning habitat does not go beyond falls with ID 155d09fe-9e10-4baf-b6fb-718d1b975506
 356362384,339,439,LFRA,CO,spawning,t,SN,2023-08-17,FISS spawning points,
 356362384,3361,3461,LFRA,CM,spawning,t,SN,2023-08-17,FISS spawning points,
 356362393,2234,2334,CHIR,SK,spawning,t,SN,2023-08-17,FISS spawning points,


### PR DESCRIPTION
Updates to habitat on Clapperton Creek.  Spawning habitat does not go beyond falls located at 50.22828139, -120.62577359.