### PR TITLE
ELKR Misc barrier and SFC habitat update

### DIFF
--- a/data/user_crossings_misc.csv
+++ b/data/user_crossings_misc.csv
@@ -24,4 +24,4 @@ user_crossing_misc_id,blue_line_key,downstream_route_measure,crossing_type,cross
 30,360844732,118,CBS,CULVERT,BARRIER,USKE,LB,2026-03-03,satellite imagery,unmapped railline
 34,356360979,74145,OTHER,BEAVER_DAM,BARRIER,LTRE,MC,2026-03-10,Tuzistol meeting,
 35,356359054,8246,OTHER,BEAVER_DAM,BARRIER,TAKL,MC,2026-03-10,Tuzistol meeting,
-36,356535716,435,CBS,CULVERT,BARRIER,ELKR,MC,2026-04-01,imagery review,unmapped road with clearly visible culvert
+36,356535716,435,CBS,CULVERT,POTENTIAL,ELKR,MC,2026-04-01,imagery review,unmapped road with clearly visible culvert

--- a/data/user_habitat_classification.csv
+++ b/data/user_habitat_classification.csv
@@ -15402,8 +15402,6 @@
 356263421,0,141,LNIC,ST,spawning,f,LB,2026-01-30,stream no longer exists according to locals,
 356336173,363,2697,LNIC,ST,rearing,f,LB,2026-01-30,,
 356336173,363,1921,LNIC,CO,rearing,f,LB,2026-01-30,,
-356122539,139,1041,SHUL,CO,rearing,f,LB,2026-02-20,,
-356240232,1427,1445,SHUL,CO,rearing,f,LB,2026-02-20,,
 356240232,1427,1445,SHUL,CO,spawning,f,LB,2026-02-24,"low quality habitat, excluded from model",
 356302405,525,2618,HORS,CO,rearing,f,MC,2026-02-25,No habitat,
 356208196,417,849,HORS,CO,rearing,f,MC,2026-02-25,No habitat,


### PR DESCRIPTION
Updating barrier status of new MISC barrier in ELKR. Undoing previous habitat removal after discussion with partners mentioning habitat might be present