### PR TITLE
Tracking table QA/QC round 2

### DIFF
--- a/data/cabd_passability_status_updates.csv
+++ b/data/cabd_passability_status_updates.csv
@@ -10,4 +10,4 @@ e8f03f80-9bbf-4f5b-8267-a6ed55dff18e,2,SN,2025-12-22,CWF TMK,Salmon House Falls 
 ce90af3f-fdf9-4bdc-8535-9412825726c9,2,SN,2025-12-23,https://a100.gov.bc.ca/pub/acat/documents/r40929/05.AS.04_Passage_1389359897936_9359222675.pdf,report indicates passability is species/flow dependent
 77cc978b-a595-4227-9641-05e2d875b3ff,1,SN,2023-08-11,New Graph Environment,Historic falls restricting salmon from Kootenay Lake and upstream
 e59c47b5-db49-4929-838a-06bbf1e5d8de,2,SN,2026-01-07,https://www.newgraphenvironment.com/fish_passage_skeena_2024_reporting/buck-falls.html#buck-falls,see report
-75e563a7-0ec8-47e3-bd20-13c96d0e9eda ,3,MC,2026-04-10,SFC tracking table QA/QC. Biologist reviewed,
+75e563a7-0ec8-47e3-bd20-13c96d0e9eda,3,MC,2026-04-10,SFC tracking table QA/QC. Biologist reviewed,

--- a/data/user_habitat_classification.csv
+++ b/data/user_habitat_classification.csv
@@ -15410,3 +15410,4 @@
 356359980,4142,8314,TAKL,SK,spawning,f,LB,2026-03-27,Takla WCRP,"The channel is described as being within a confined gully, and sockeye may not be able to access 8.4km upstream/to falls barrier."
 356299109,3923,10592,USHU,CO,rearing,f,MC,2026-04-14,Tracking table QA/QC,No key upstream habitat from 199643
 356234357,0,358,USHU,CO,rearing,f,MC,2026-04-14,Tracking table QA/QC,No key upstream habitat from 199643
+356299109,3923,7241,USHU,CO,spawning,f,MC,2026-04-14,Tracking table QA/QC,No key upstream habitat from 199643


### PR DESCRIPTION
75e563a7-0ec8-47e3-bd20-13c96d0e9eda disappeared after this fix table entry, I wonder if the accidental space after the id is the culprit. 

@smnorris Could you please merge this before the end of the day for a model run overnight.