### PR TITLE
tho-shu-fixes-2026-04-23

### DIFF
--- a/data/user_habitat_classification.csv
+++ b/data/user_habitat_classification.csv
@@ -15613,7 +15613,7 @@ blue_line_key,downstream_route_measure,upstream_route_measure,watershed_group_co
 356299109,3923,10592,USHU,CO,,-1,LB,2026-04-17,field assessment,low quality habitat
 356234357,0,357,USHU,CO,,-1,LB,2026-04-17,field assessment,low quality habitat
 356347377,557,5102,BONP,ST,,-1,LB,2026-04-20,field assessment,no habitat upstream of crossing located on Caribou Hwy.
-356240232,1427,1445,SHUL,CO,,-1,LB,2026-04-20,field assessment,confirmation from SFC that habitat can be removed. There is a small amount on the west trib upstream of this point that can also be removed.
+356240232,1427,1445,SHUL,CO,-1,-1,LB,2026-04-20,field assessment,confirmation from SFC that habitat can be removed. There is a small amount on the west trib upstream of this point that can also be removed.
 356568928,328,341,ELKR,WCT,,-1,MC,2026-04-20,Tracking table QA/QC,"Low quality habitat, confirmed with Working Group. Dry channel at time of assessment, transitions into grass flats 60 m downstream of crossing."
 356348664,503,2685,LNIC,ST,,-1,LB,2026-04-21,model qa/qc,No upstream habitat. Too steep to access from Coldwater River
 356330403,1118,1321,LNIC,ST,,-1,LB,2026-04-21,model qa/qc,no habitat upstream of crossing

--- a/data/user_pscis_barrier_status.csv
+++ b/data/user_pscis_barrier_status.csv
@@ -1374,3 +1374,4 @@ stream_crossing_id,user_barrier_status,watershed_group_code,reviewer_name,review
 197532,PASSABLE,ELKR,MC,2024-04-16,Tracking table QA/QC
 197867,PASSABLE,ELKR,MC,2024-04-16,Tracking table QA/QC
 197880,PASSABLE,LNIC,LB,2026-04-21,Passable to adult fish at all flows and to juvenile coho at low flows; 87.5% of juvenile coho at higher flows.
+199409,PASSABLE,SHUL,LB,2026-04-23,This feature is passable according to field assessment.


### PR DESCRIPTION
-coho spawning removed from 356240232.  I had only removed rearing in the previous PR, so I added -1 to the spawning column for record 15616.