### PR TITLE
lnic-fix-2026-05-08

### DIFF
--- a/data/user_crossings_misc.csv
+++ b/data/user_crossings_misc.csv
@@ -1,5 +1,4 @@
 user_crossing_misc_id,blue_line_key,downstream_route_measure,crossing_type,crossing_subtype,barrier_status,watershed_group_code,reviewer_name,review_date,source,notes
-1,356334818,3697,OTHER,WEIR,BARRIER,LNIC,FINS CONSULTING,2021-01-01,field assessment,0.8m high and 5m wide concrete weir with a concrete foot is impassable to fish. Located 25m u/s of culvert
 3,356348405,211,CBS,CULVERT,BARRIER,QUES,AL,2023-05-15,local knowledge,Long culvert based on information provided by Bo and Jake at LDN workshop.
 4,356348405,3235,CBS,CULVERT,BARRIER,QUES,AL,2023-05-15,local knowledge,"Culvert based on information provided by participants at LDN workshop (Chris Elden, West Fraser)."
 5,356136908,163,CBS,CULVERT,BARRIER,BOWR,AL,2023-05-15,local knowledge,"Ditch line crossing based on information provided by participants at LDN workshop (Chris Elden, West Fraser)."


### PR DESCRIPTION
removal of record where user_crossing_id = 1.  This feature exists and is mapped correctly (25 m upstream of culvert 197681) in the CABD
