### PR TITLE
Update grants on ranked barriers table

### DIFF
--- a/jobs/rank_barriers.py
+++ b/jobs/rank_barriers.py
@@ -766,6 +766,9 @@ def runQuery(condition, wcrp, wcrp_schema, connectivity_status_types, target_spe
             inner join bcfishpass.crossings_wcrp_vw cv
                 on c.aggregated_crossings_id = cv.aggregated_crossings_id
             order by rank_combined;
+
+            ALTER TABLE IF EXISTS wcrp_{wcrp_schema}.ranked_barriers_{wcrp}
+                OWNER TO simonn;
         """
         cursor.execute(q_wcrp_rank_table)
 


### PR DESCRIPTION
Updated rank_barriers.py. Added grant giving ownership of table wcrp_{wcrp_schema}.ranked_barriers_{wcrp} to user simonn to allow dropping the table via GitHub Actions.