### PR TITLE
Add PINE watershed group to newgraph habitat method

### DIFF
--- a/parameters/example_newgraph/parameters_habitat_method.csv
+++ b/parameters/example_newgraph/parameters_habitat_method.csv
@@ -129,6 +129,7 @@ PARA,cw
 PARK,cw
 PARS,cw
 PCEA,cw
+PINE,cw
 PORI,cw
 QUES,cw
 REVL,cw


### PR DESCRIPTION
Adds the Pine watershed group (PINE) to the newgraph habitat method parameters so it is included in modelling. Inserted alphabetically with model cw, consistent with all other watershed groups in this config.